### PR TITLE
Fixed benchmarking of all Claymore Dual mining and profit calculations

### DIFF
--- a/Miners/ClaymoreDecred20.txt
+++ b/Miners/ClaymoreDecred20.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Decred.Host):$($Pools.Decred.Port) -dwal $($Pools.Decred.User) -dpsw $($Pools.Decred.Pass) -dcoin dcr -dcri 20",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual20_Ethash_HashRate.Week)","Decred":  "$($Stats.ClaymoreDual20_Decred_HashRate.Week)"},
+        "HashRates":  {"Decred":  "$($Stats.ClaymoreDecred20_Ethash_HashRate.Week)","Ethash":  "$($Stats.ClaymoreDecred20_Decred_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreDecred30.txt
+++ b/Miners/ClaymoreDecred30.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Decred.Host):$($Pools.Decred.Port) -dwal $($Pools.Decred.User) -dpsw $($Pools.Decred.Pass) -dcoin dcr -dcri 30",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual30_Ethash_HashRate.Week)","Decred":  "$($Stats.ClaymoreDual30_Decred_HashRate.Week)"},
+        "HashRates":  {"Decred":  "$($Stats.ClaymoreDecred30_Ethash_HashRate.Week)","Ethash":  "$($Stats.ClaymoreDecred30_Decred_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreDecred40.txt
+++ b/Miners/ClaymoreDecred40.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Decred.Host):$($Pools.Decred.Port) -dwal $($Pools.Decred.User) -dpsw $($Pools.Decred.Pass) -dcoin dcr -dcri 40",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual40_Ethash_HashRate.Week)","Decred":  "$($Stats.ClaymoreDual40_Decred_HashRate.Week)"},
+        "HashRates":  {"Decred":  "$($Stats.ClaymoreDecred40_Ethash_HashRate.Week)","Ethash":  "$($Stats.ClaymoreDecred40_Decred_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreLbry20.txt
+++ b/Miners/ClaymoreLbry20.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Lbry.Host):$($Pools.Lbry.Port) -dwal $($Pools.Lbry.User) -dpsw $($Pools.Lbry.Pass) -dcoin lbc -dcri 20",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual20_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreDual20_Lbry_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreLbry20_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreLbry20_Lbry_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreLbry30.txt
+++ b/Miners/ClaymoreLbry30.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Lbry.Host):$($Pools.Lbry.Port) -dwal $($Pools.Lbry.User) -dpsw $($Pools.Lbry.Pass) -dcoin lbc -dcri 30",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual30_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreDual30_Lbry_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreLbry30_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreLbry30_Lbry_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreLbry40.txt
+++ b/Miners/ClaymoreLbry40.txt
@@ -1,9 +1,9 @@
-[
+[
     {
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Lbry.Host):$($Pools.Lbry.Port) -dwal $($Pools.Lbry.User) -dpsw $($Pools.Lbry.Pass) -dcoin lbc -dcri 40",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual40_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreDual40_Lbry_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreLbry40_Ethash_HashRate.Week)","Lbry":  "$($Stats.ClaymoreLbry40_Lbry_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymorePascal20.txt
+++ b/Miners/ClaymorePascal20.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Pascal.Host):$($Pools.Pascal.Port) -dwal $($Pools.Pascal.User) -dpsw $($Pools.Pascal.Pass) -dcoin pasc -dcri 20",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual20_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymoreDual20_Pascal_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymorePascal20_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymorePascal20_Pascal_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymorePascal30.txt
+++ b/Miners/ClaymorePascal30.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Pascal.Host):$($Pools.Pascal.Port) -dwal $($Pools.Pascal.User) -dpsw $($Pools.Pascal.Pass) -dcoin pasc -dcri 30",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual30_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymoreDual30_Pascal_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymorePascal30_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymorePascal30_Pascal_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymorePascal40.txt
+++ b/Miners/ClaymorePascal40.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Pascal.Host):$($Pools.Pascal.Port) -dwal $($Pools.Pascal.User) -dpsw $($Pools.Pascal.Pass) -dcoin pasc -dcri 40",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual40_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymoreDual40_Pascal_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymorePascal40_Ethash_HashRate.Week)","Pascal":  "$($Stats.ClaymorePascal40_Pascal_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreSia20.txt
+++ b/Miners/ClaymoreSia20.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Sia.Host):$($Pools.Sia.Port) -dwal $($Pools.Sia.User) -dpsw $($Pools.Sia.Pass) -dcoin sc -dcri 20",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual20_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreDual20_Sia_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia20_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreSia20_Sia_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false
@@ -12,7 +12,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.SiaClaymore.Host):$($Pools.SiaClaymore.Port) -dwal $($Pools.SiaClaymore.User) -dpsw $($Pools.SiaClaymore.Pass) -dcoin sc -dcri 20",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual20_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreDual20_SiaClaymore_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia20_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreSia20_SiaClaymore_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreSia30.txt
+++ b/Miners/ClaymoreSia30.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Sia.Host):$($Pools.Sia.Port) -dwal $($Pools.Sia.User) -dpsw $($Pools.Sia.Pass) -dcoin sc -dcri 30",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual30_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreDual30_Sia_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia30_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreSia30_Sia_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false
@@ -12,7 +12,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.SiaClaymore.Host):$($Pools.SiaClaymore.Port) -dwal $($Pools.SiaClaymore.User) -dpsw $($Pools.SiaClaymore.Pass) -dcoin sc -dcri 30",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual30_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreDual30_SiaClaymore_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia30_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreSia30_SiaClaymore_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false

--- a/Miners/ClaymoreSia40.txt
+++ b/Miners/ClaymoreSia40.txt
@@ -3,7 +3,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.Sia.Host):$($Pools.Sia.Port) -dwal $($Pools.Sia.User) -dpsw $($Pools.Sia.Pass) -dcoin sc -dcri 40",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual40_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreDual40_Sia_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia40_Ethash_HashRate.Week)","Sia":  "$($Stats.ClaymoreSia40_Sia_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false
@@ -12,7 +12,7 @@
         "Type":  ["AMD","NVIDIA"],
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
         "Arguments":  "-epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -dpool $($Pools.SiaClaymore.Host):$($Pools.SiaClaymore.Port) -dwal $($Pools.SiaClaymore.User) -dpsw $($Pools.SiaClaymore.Pass) -dcoin sc -dcri 40",
-        "HashRates":  {"Ethash":  "$($Stats.ClaymoreDual40_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreDual40_SiaClaymore_HashRate.Week)"},
+        "HashRates":  {"Ethash":  "$($Stats.ClaymoreSia40_Ethash_HashRate.Week)","SiaClaymore":  "$($Stats.ClaymoreSia40_SiaClaymore_HashRate.Week)"},
         "API":  "Claymore",
         "Port":  "3333",
         "Wrap":  false


### PR DESCRIPTION
Corrected all the filenames created by the benchmarking in the miner files so they accurately read what is being written.

Note for Decred it appears that the Decred benchmark stats are getting written to the Ethash file and the Ethash benchmarks are in the Decred file.   I believe this will need to be corrected in the main Get-Stat portion of the Multipoolminer.ps1.  It is likely because something is alphabetizing it and Decred comes before Ethash.  The correction I made to the miner is a work around so that it correctly calculates profits until the other bug is fixed.  I tested Sia and Lbry as well and they are working correctly.  There is no Pascal coin on zpool or miningpoolhub so no test for that yet.