### PR TITLE
Zpool moved x11, quark, and qubit to GH instead of MH

### DIFF
--- a/Pools/Zpool.ps1
+++ b/Pools/Zpool.ps1
@@ -26,6 +26,9 @@ $Zpool_Request | Get-Member -MemberType NoteProperty | Select-Object -ExpandProp
         "blake2s" {$Divisor *= 1000}
         "blakecoin" {$Divisor *= 1000}
         "decred" {$Divisor *= 1000}
+        "x11" {$Divisor *= 1000}
+        "quark" {$Divisor *= 1000}
+        "qubit" {$Divisor *= 1000}
     }
 
     if ((Get-Stat -Name "$($Name)_$($Zpool_Algorithm)_Profit") -eq $null) {$Stat = Set-Stat -Name "$($Name)_$($Zpool_Algorithm)_Profit" -Value ([Double]$Zpool_Request.$_.estimate_last24h / $Divisor)}


### PR DESCRIPTION
Zpool changes the profit calculations on x11, quark, and qubit to be measured in GH instead of MH so it is inline with Nicehash.  Causing profits to seem unusually high for these algorithms.