### PR TITLE
reduce cpu useage when idling between main loop cycles.

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -291,7 +291,7 @@ function Start-SubProcess {
         while ($Process.HasExited -eq $false)
     }
 
-    do {Start-Sleep 1; $JobOutput = Receive-Job $Job}
+    do {Start-Sleep -s 1; $JobOutput = Receive-Job $Job}
     while ($JobOutput -eq $null)
 
     $Process = Get-Process | Where-Object Id -EQ $JobOutput.ProcessId

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -136,7 +136,7 @@ while ($true) {
     if ($AllPools.Count -eq 0) {
         Write-Warning "No pools available. "
         if ($Downloader) {$Downloader | Receive-Job}
-        Start-Sleep $Interval
+        Start-Sleep -s $Interval
         continue
     }
     $Pools = [PSCustomObject]@{}
@@ -254,7 +254,7 @@ while ($true) {
     if ($Miners.Count -eq 0) {
         Write-Warning "No miners available. "
         if ($Downloader) {$Downloader | Receive-Job}
-        Start-Sleep $Interval
+        Start-Sleep -s $Interval
         continue
     }
     $ActiveMiners | ForEach-Object {
@@ -515,7 +515,7 @@ while ($true) {
     #Do nothing for a few seconds as to not overload the APIs and display miner download status
     for ($i = $Strikes; $i -gt 0 -or $Timer -lt $StatEnd; $i--) {
         if ($Downloader) {$Downloader | Receive-Job}
-        Start-Sleep 10
+        Start-Sleep -s 10
         $Timer = (Get-Date).ToUniversalTime()
     }
 

--- a/Wrapper.ps1
+++ b/Wrapper.ps1
@@ -27,7 +27,7 @@ $Job = Start-Job -ArgumentList $FilePath, $ArgumentList, $WorkingDirectory {
 Write-Host "MultiPoolMiner Wrapper Started" -BackgroundColor Yellow -ForegroundColor Black
 
 do {
-    Start-Sleep 1
+    Start-Sleep -s 1
 
     $Job | Receive-Job | ForEach-Object {
         $Line = $_


### PR DESCRIPTION
MultiPoolMiner will no longer use CPU when it is idle waiting for the next process loop.

This addresses complaints that MultiPoolMiner was taking up CPU usage, and slowing down CPU miners. 