### PR TITLE
Use Resolve-Path instead of [System.IO.Path]

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -240,8 +240,8 @@ while ($true) {
         $Miner | Add-Member Device ($Miner_Devices | Sort-Object) -Force
         $Miner | Add-Member Device_Auto (($Miner_Devices -eq $null) | Sort-Object) -Force
 
-        $Miner.Path = [System.IO.Path]::GetFullPath($Miner.Path)
-        if ($Miner.PrerequisitePath) {$Miner.PrerequisitePath = [System.IO.Path]::GetFullPath($Miner.PrerequisitePath)}
+        $Miner.Path = (Resolve-Path $Miner.Path).Path
+        if ($Miner.PrerequisitePath) {$Miner.PrerequisitePath = (Resolve-Path $Miner.PrerequisitePath).Path}
 
         if (-not $Miner.API) {$Miner | Add-Member API "Miner" -Force}
     }

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -240,8 +240,8 @@ while ($true) {
         $Miner | Add-Member Device ($Miner_Devices | Sort-Object) -Force
         $Miner | Add-Member Device_Auto (($Miner_Devices -eq $null) | Sort-Object) -Force
 
-        $Miner.Path = (Resolve-Path $Miner.Path).Path
-        if ($Miner.PrerequisitePath) {$Miner.PrerequisitePath = (Resolve-Path $Miner.PrerequisitePath).Path}
+        $Miner.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Miner.Path)
+        if ($Miner.PrerequisitePath) {$Miner.PrerequisitePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Miner.PrerequisitePath)}
 
         if (-not $Miner.API) {$Miner | Add-Member API "Miner" -Force}
     }


### PR DESCRIPTION
The powershell way of resolving a relative path to a full one is to use Resolve-Path.

This doesn't matter if you are launching the powershell script through a batch file.  But if you are launching MultiPoolMiner.ps1 directly, [System.IO.Path] doesn't use the proper starting directory.

With this small change, it will always use paths relative to the script's current directory (since it's set with Set-Location at the top).

It's probably more OS-agnostic as well, since linux support seems to be one of the long term goals.