### PR TITLE
Update PhoenixMiner to 2.9e

### DIFF
--- a/Miners/PhoenixMinerAmd29e.txt
+++ b/Miners/PhoenixMinerAmd29e.txt
@@ -8,7 +8,7 @@
                       },
         "API":  "Claymore",
         "Port":  "23335",
-        "URI":  "https://github.com/iwtym/iwtym-phoenix/archive/master.zip"
+        "URI":  "hhttps://github.com/MultiPoolMiner/miner-binaries/releases/download/phoenixminer/PhoenixMiner_2.9e.zip"
     },
     {
         "Type":  "AMD",
@@ -19,6 +19,6 @@
                       },
         "API":  "Claymore",
         "Port":  "23335",
-        "URI":  "https://github.com/iwtym/iwtym-phoenix/archive/master.zip"
+        "URI":  "https://github.com/MultiPoolMiner/miner-binaries/releases/download/phoenixminer/PhoenixMiner_2.9e.zip"
     }
 ]

--- a/Miners/PhoenixMinerNvidia29e.txt
+++ b/Miners/PhoenixMinerNvidia29e.txt
@@ -8,7 +8,7 @@
                       },
         "API":  "Claymore",
         "Port":  "23334",
-        "URI":  "https://github.com/iwtym/iwtym-phoenix/archive/master.zip"
+        "URI":  "https://github.com/MultiPoolMiner/miner-binaries/releases/download/phoenixminer/PhoenixMiner_2.9e.zip"
     },
     {
         "Type":  "NVIDIA",
@@ -19,6 +19,6 @@
                       },
         "API":  "Claymore",
         "Port":  "23334",
-        "URI":  "https://github.com/iwtym/iwtym-phoenix/archive/master.zip"
+        "URI":  "https://github.com/MultiPoolMiner/miner-binaries/releases/download/phoenixminer/PhoenixMiner_2.9e.zip"
     }
 ]


### PR DESCRIPTION
The original files were renamed in place to keep both. 2.9e has some stability issued with Maxwell cards - thus the 2.8c version should remain. Some have reported no hashrate difference on some cards.

I don't own AMD cards - so I went with the modification by intuition. I have not tested this on AMD cards.